### PR TITLE
Bugfixes for 0.2.0 release

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -1,5 +1,5 @@
 name = "ethernet_io"
-version = "0.2.0"
+version = "0.2.1"
 [dependencies]
 jsl = { git = "JITx-Inc/jsl", version = "0.9.1"}
 connectors = { git = "JITx-Inc/connectors", version = "0.4.0" }

--- a/slm.toml
+++ b/slm.toml
@@ -1,13 +1,13 @@
 name = "ethernet_io"
 version = "0.2.0"
 [dependencies]
-jsl = { git = "JITx-Inc/jsl", version = "0.9.0"}
+jsl = { git = "JITx-Inc/jsl", version = "0.9.1"}
 connectors = { git = "JITx-Inc/connectors", version = "0.4.0" }
 FTDI = { git = "JITx-Inc/FTDI", version = "0.3.3" }
 jlc-pcb = { git = "JITx-Inc/jlc-pcb", version = "0.3.0" }
 stmicro = { git = "JITx-Inc/stmicro", version = "0.4.0" }
-TI-vreg = { git = "JITx-Inc/TI-VREG", version = "0.3.1" }
-microchip-networking = { git = "JITx-Inc/microchip-networking", version = "0.5.0" }
+TI-vreg = { git = "JITx-Inc/TI-VREG", version = "0.3.2" }
+microchip-networking = { git = "JITx-Inc/microchip-networking", version = "0.6.0" }
 EEPROM = { git = "JITx-Inc/EEPROM", version = "0.3.2" }
 debug = { git = "JITx-Inc/debug", version = "0.3.3" }
 diodes = { git = "JITx-Inc/diodes", version = "0.2.0" }

--- a/src/main.stanza
+++ b/src/main.stanza
@@ -138,33 +138,29 @@ public pcb-module comms-core :
     route-struct = diff-routing-struct(substrate, 100)
   )
   for i in 0 to length(eth-if.conns) do:
-    require MDI : MDI-1000Base-T from netsw.netsw
+    ; We have to use a special bundle type that includes the LEDs
+    ;   so the proper LED control pins connected to the right ethernet
+    ;   connector.
+    val P-bundle = microchip-networking/components/KSZ9563/MDI-1000BaseT-With-LEDs
+    require P : P-bundle  from netsw.netsw
     require conn-IF : MDI-1000Base-T from eth-if.conns[i]
 
-    within [src, dst] = constrain-topology(MDI => conn-IF, mdi-constraint):
+    within [src, dst] = constrain-topology(P.MDI => conn-IF, mdi-constraint):
       require prot-MDI : dual-pair[NUM_PAIRS_1000Base-T] from esd
 
       topology MDI (src.TP => dst.TP)
       for i in 0 to NUM_PAIRS_1000Base-T do:
         topo-pair(src.TP[i] => prot-MDI[i].A => prot-MDI[i].B  => dst.TP[i])
 
-  ;;  ----  LED Setup ------
-  ; The RJ45 connectors have embedded LEDs - so we will use
-  ;  drive those LEDs from the netsw component
-
-  val LED-R = 330.0
-
-  ; val LED-pts = [netsw.netsw.C.LED1, netsw.netsw.C.LED2]
-  for (i in 0 to length(eth-if.conns)) do:
+    ; Connect LEDs
+    val LED-R = 330.0
     val led-g = eth-if.conns[i].LED-G
     insert-resistor(rail-3v3.V+, led-g.a, R-query, resistance = LED-R)
-    ; net (led-g.c, LED-pt[0])
-    net (led-g.c, netsw.LEDs[i][0])
+    net (led-g.c, P.LED[0])
 
     val led-y = eth-if.conns[i].LED-Y
     insert-resistor(rail-3v3.V+, led-y.a, R-query, resistance = LED-R)
-    ; net (led-y.c, LED-pt[1])
-    net (led-y.c, netsw.LEDs[i][1])
+    net (led-y.c, P.LED[1])
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   ; Microcontroller

--- a/src/power.stanza
+++ b/src/power.stanza
@@ -106,7 +106,6 @@ public pcb-module power-mng:
     C-query? = C-query
     )
 
-  ; inst DCDC-3v3 : DCDC-5V-to-3v3
   net (USB-OR.vout, DCDC-3v3.conv.VIN)
   net (DCDC-3v3.conv.VOUT, VDD-3v3)
 
@@ -144,7 +143,6 @@ public pcb-module power-mng:
     )
 
 
-  ; inst DCDC-1v2 : DCDC-5V-to-1v2
   net (USB-OR.vout, DCDC-1v2.conv.VIN)
   net (DCDC-1v2.conv.VOUT, VDD-1v2)
 


### PR DESCRIPTION
1.  Fixed issues in the TI vreg not connecting PG and enable
2.  Fixed potential sync issue between MDI and LEDs for the network switch
3.  Increment JSL to version 0.9.1
4.  Bump to 0.2.1